### PR TITLE
fix image stored files were never retrieved in file storage

### DIFF
--- a/classes/pdf.php
+++ b/classes/pdf.php
@@ -731,7 +731,7 @@ class dataformview_pdf_pdf extends mod_dataform\pluginbase\dataformview {
                 $filearea = array_shift($pathparts);
 
                 $hash = urldecode(array_shift($pathparts));
-                $filename = array_pop($pathparts);
+                $filename = urldecode(array_pop($pathparts));
                 $filepath = '/' . implode('/', $pathparts);
                 $itemid = $component == 'mod_dataform' ? $this->df->get_content_id_from_hash($hash) : $hash;
 

--- a/classes/pdf.php
+++ b/classes/pdf.php
@@ -719,23 +719,23 @@ class dataformview_pdf_pdf extends mod_dataform\pluginbase\dataformview {
 
         // Process pluginfile images.
         $imagetypes = get_string('imagetypes', 'dataformview_pdf');
-        $contextid = $this->df->get_context()->id;
-        $component = 'mod_dataform';
-        $filearea = 'content';
-        $baseurl = "$CFG->wwwroot/pluginfile.php/$contextid/$component/$filearea/";
+        $baseurl = "$CFG->wwwroot/pluginfile.php/";
 
         if (preg_match_all("%$baseurl([^.]+.($imagetypes))%", $content, $matches)) {
             $replacements = array();
-
             $fs = get_file_storage();
             foreach ($matches[1] as $imagepath) {
                 $pathparts = explode('/', $imagepath);
+                $contextid = array_shift($pathparts);
+                $component = array_shift($pathparts);
+                $filearea = array_shift($pathparts);
+
                 $hash = urldecode(array_shift($pathparts));
                 $filename = array_pop($pathparts);
                 $filepath = '/' . implode('/', $pathparts);
-                $contentid = $this->df->get_content_id_from_hash($hash);
+                $itemid = $component == 'mod_dataform' ? $this->df->get_content_id_from_hash($hash) : $hash;
 
-                if (!$file = $fs->get_file($contextid, $component, $filearea, $contentid, $filepath, $filename) or $file->is_directory()) {
+                if (!$file = $fs->get_file($contextid, $component, $filearea, $itemid, $filepath, $filename) or $file->is_directory()) {
                     continue;
                 }
                 $filename = $file->get_filename();


### PR DESCRIPTION
Hi,
the hash of the file path you used to retrieve an image stored file was not the same as the one that was calculated when the image file was stored.
The variables `$component` and `$filearea` I used in my patch should not be hardcoded, but I didn't find any good solution for now and have no more time to investigate a better solution.